### PR TITLE
add continuous gridworld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ __pycache__
 *#
 *~
 *.pyc
+lib/
+sparse/build
 
 figs/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+cd sparse
+python3 setup.py install --home=../
+cd ..
+touch lib/__init__.py
+touch lib/python/__init__.py

--- a/environments/ContinuousGridworld.py
+++ b/environments/ContinuousGridworld.py
@@ -1,0 +1,53 @@
+from environments.Environment import Environment
+import numpy as np
+
+class CtsGridWorld(Environment):
+    _x = 0
+    _y = 0
+
+    steps = 0
+    stepSize = 0.05
+    noise = 0.01
+
+    def __init__(self, maxSteps):
+        self.maxSteps = maxSteps
+
+    def getReward(self):
+        if self._x + self.stepSize >= 1 and self._y + self.stepSize >= 1:
+            return 1
+        return 0
+
+    def step(self, action):
+        noise = np.random.normal(0, self.noise)
+        if action == 0:
+            self._x = bound(self._x + self.stepSize + noise, 0, 1)
+        elif action == 1:
+            self._y = bound(self._y + self.stepSize + noise, 0, 1)
+        elif action == 2:
+            self._x = bound(self._x - self.stepSize + noise, 0, 1)
+        elif action == 3:
+            self._y = bound(self._y - self.stepSize + noise, 0, 1)
+
+        r = self.getReward()
+        self.steps += 1
+        done = r == 1 or self.maxSteps == self.steps
+
+        return (np.array([self._x, self._y]), r, done, action)
+
+    def reset(self):
+        self.steps = 0
+        self._x = 0
+        self._y = 0
+
+        return np.array([0, 0])
+
+    def observationShape(self):
+        return [1, 1]
+
+    def numActions(self):
+        return 4
+
+def bound(x, min, max):
+    b = max if x >= max else x
+    b = 0 if b <= min else b
+    return b

--- a/environments/Environment.py
+++ b/environments/Environment.py
@@ -10,8 +10,3 @@ class Environment:
 
     def numActions(self):
         raise NotImplementedError()
-
-
-    def step(self):
-        step()
-        reward = self.reward_callback

--- a/q_learning.py
+++ b/q_learning.py
@@ -26,6 +26,7 @@ from agents.UCB import UCB
 
 # environments
 from environments.gridworld import GridWorld
+from environments.ContinuousGridworld import CtsGridWorld
 
 def runExperiment(env, num_episodes, agent):
   total_reward = 0
@@ -57,6 +58,7 @@ def runExperiment(env, num_episodes, agent):
 
     steps.append(step)
     print(episode, step)
+    # agent.print()
 
   return (steps, rewards)
 
@@ -90,7 +92,8 @@ fig = plt.figure()
 ax = plt.axes()
 
 # def main():
-env = GridWorld([30, 30], 700)
+# env = GridWorld([30, 30], 700)
+env = CtsGridWorld(400)
 
 # Optimal for riverswim, doesn't make sense on gridworld
 # (rewards, stderr) = averageOverRuns(Optimal, env, 20)
@@ -99,8 +102,8 @@ env = GridWorld([30, 30], 700)
 # (rewards, stderr) = averageOverRuns(Q, env, 1)
 # plotRewards(ax, rewards, stderr, 'Q epsilon=0.1')
 
-(rewards, stderr) = averageOverRuns(TabularQ, env, 1)
-plotRewards(ax, rewards, stderr, 'Q epsilon=0.1')
+# (rewards, stderr) = averageOverRuns(TabularQ, env, 1)
+# plotRewards(ax, rewards, stderr, 'Q epsilon=0.1')
 #
 # (rewards, stderr) = averageOverRuns(UCB, env, 5)
 # plotRewards(ax, rewards, stderr, 'UCB')

--- a/sparse/setup.py
+++ b/sparse/setup.py
@@ -1,0 +1,17 @@
+from distutils.core import setup, Extension
+import numpy as np
+
+module1 = Extension('sparse',
+                    sources = ['sparse_module.c'])
+
+setup (name = 'sparse',
+       version = '1.0',
+       description = 'This is a demo package',
+       ext_modules = [module1],
+       include_dirs = [np.get_include()])
+
+# setup (name = 'tiles',
+#        version = '1.0',
+#        description = 'This is a demo package',
+#        ext_modules = [module2],
+#        include_dirs = [np.get_include()])

--- a/sparse/sparse_module.c
+++ b/sparse/sparse_module.c
@@ -1,0 +1,121 @@
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <Python.h>
+#include <numpy/arrayobject.h>
+
+static void init(void) {
+    if (PyArray_API == NULL) {
+        if (_import_array() < 0) {
+            PyErr_Print();
+            PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import");
+        }
+    }
+}
+
+static void FillLongVectorFromList(long* out, PyObject *list, int size) {
+    int i = 0;
+    for (i = 0; i < size; ++i) {
+        PyObject* o = PyList_GetItem(list, i);
+        out[i] = PyLong_AsLong(o);
+    }
+}
+
+static PyObject* VectorMatrixProduct(PyObject *self, PyObject *args) {
+    // Parse arguments
+    PyArrayObject* raw_np;
+    PyObject *listObj;
+    if (!PyArg_ParseTuple(args, "O!O!", &PyList_Type, &listObj, &PyArray_Type, &raw_np)) return NULL;
+    const int num_ones = PyList_Size(listObj);
+    const npy_intp* data_dims = PyArray_DIMS(raw_np);
+    long *ones = malloc(num_ones * sizeof(double));
+    FillLongVectorFromList(ones, listObj, num_ones);
+
+    const int cols = data_dims[1];
+    int np_dims[] = {1, cols};
+    PyArrayObject* out_array = (PyArrayObject*) PyArray_FromDims(2, np_dims, NPY_DOUBLE);
+
+    // Perform multiplication
+    double* out_data = PyArray_DATA(out_array);
+    int c = 0;
+    int j = 0;
+    for (c = 0; c < cols; ++c) {
+        double sum = 0.0;
+        for (j = 0; j < num_ones; ++j) {
+            int one = ones[j];
+            npy_intp ind[] = {one, c};
+            double* dat = (double*)PyArray_GetPtr(raw_np, ind);
+            sum += *dat;
+        }
+        out_data[c] = sum;
+    }
+
+    // Py_INCREF(out_array);
+    free(ones);
+    return (PyObject*) out_array;
+}
+
+static PyObject* VectorDotProduct(PyObject *self, PyObject *args) {
+    PyArrayObject* raw_np;
+    PyObject* listObj;
+    if (!PyArg_ParseTuple(args, "O!O!", &PyList_Type, &listObj, &PyArray_Type, &raw_np)) return NULL;
+    const int num_ones = PyList_Size(listObj);
+    long *ones = malloc(num_ones * sizeof(double));
+    FillLongVectorFromList(ones, listObj, num_ones);
+
+    double sum = 0.0;
+    int c = 0;
+    for (c = 0; c < num_ones; ++c) {
+        npy_intp ind[] = {0, ones[c]};
+        double* dat = (double*)PyArray_GetPtr(raw_np, ind);
+        sum += *dat;
+    }
+
+    free(ones);
+    return PyFloat_FromDouble(sum);
+}
+
+static PyObject* MatrixDotProduct(PyObject *self, PyObject *args) {
+    PyArrayObject* raw_np;
+    PyObject* listObj;
+    if (!PyArg_ParseTuple(args, "O!O!", &PyList_Type, &listObj, &PyArray_Type, &raw_np)) return NULL;
+    const int num_ones = PyList_Size(listObj);
+    long *ones = malloc(num_ones * sizeof(double));
+    FillLongVectorFromList(ones, listObj, num_ones);
+
+    double sum = 0.0;
+    int c = 0;
+    for (c = 0; c < num_ones; ++c) {
+        npy_intp ind[] = {ones[c], 0};
+        double* dat = (double*)PyArray_GetPtr(raw_np, ind);
+        sum += *dat;
+    }
+
+    free(ones);
+    return PyFloat_FromDouble(sum);
+}
+
+//--------------------------------
+//--------------------------------
+
+
+
+static PyMethodDef SparseMethods[] = {
+    {"VectorMatrixProduct",  VectorMatrixProduct, METH_VARARGS, "Do a sparse vector by dense matrix product."},
+    {"VectorDotProduct", VectorDotProduct, METH_VARARGS, "Do a sparse vector by dense vector dot product."},
+    {"MatrixDotProduct", MatrixDotProduct, METH_VARARGS, "Do a sparse vector by dense (n, 1) matrix dot product."},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+static struct PyModuleDef sparseMod = {
+    PyModuleDef_HEAD_INIT,
+    "sparse",   /* name of module */
+    NULL, /* module documentation, may be NULL */
+    -1,       /* size of per-interpreter state of the module,
+                 or -1 if the module keeps state in global variables. */
+    SparseMethods
+};
+
+PyMODINIT_FUNC PyInit_sparse(void) {
+    PyObject *m = PyModule_Create(&sparseMod);
+    init();
+    return m;
+}

--- a/sparse/test.py
+++ b/sparse/test.py
@@ -1,0 +1,35 @@
+import sparse
+import numpy as np
+
+def vdot(s, V):
+    return np.array(float(sum(V[0, s])))
+
+def mdot(s, V):
+    return np.array(float(sum(V[s, 0])))
+
+def vmProd(s, V):
+    out = np.zeros((1, V.shape[1]))
+    for c in range(V.shape[1]):
+        out[0, c] = float(sum(V[s, c]))
+    return out
+
+
+for run in range(100):
+    # test vmProd
+    n = np.random.randn(512, 512)
+    s = [i for i in range(0, 512, 20)]
+    m = sparse.VectorMatrixProduct(s, n)
+    o = vmProd(s, n)
+    print(np.linalg.norm(o - m))
+
+    # test mdot
+    n = np.random.rand(512, 1)
+    m = sparse.MatrixDotProduct(s, n)
+    o = mdot(s, n)
+    print(np.linalg.norm(o - m))
+
+    # test vdot
+    n = np.random.randn(1, 512)
+    m = sparse.VectorDotProduct(s, n)
+    o = vdot(s, n)
+    print(np.linalg.norm(o - m))

--- a/utils/math.py
+++ b/utils/math.py
@@ -6,6 +6,7 @@ import numpy as np
 def argMax(arr):
     indices = np.where(arr == np.max(arr))[0]
     if len(indices) < 1:
+        print(arr)
         raise ArithmeticError()
 
     return np.random.choice(indices)

--- a/utils/sparse.py
+++ b/utils/sparse.py
@@ -1,0 +1,116 @@
+import lib.python.sparse as sparse
+from utils.TileCoding import TileCoding
+import numpy as np
+
+# This is a sparse vector for doing very fast dot products and additions.
+# It is approximately 10x faster than scipy.sparse but it is not nearly as complete.
+# Right now, it has not been tested for matrix/vector multiplications
+class SparseOneVector(object):
+    def __new__(cls, ones, length, _T = False):
+        m = object.__new__(cls)
+        m.ones = ones
+        if not _T:
+            m.shape = (length,)
+            m.T = cls(ones, length, _T = True)
+        else:
+            m.shape = (length, 1)
+        return m
+
+    # Get back a numpy array (in case you need a feature that isn't/can't be implemented here)
+    def array(self):
+        m = np.zeros(self.shape)
+        m[self.ones] = 1
+        return m
+
+    # Don't use me. Use dot instead
+    def outer(self, V):
+        out = np.zeros((self.shape[0], V.shape[1]))
+        out[self.ones, :] = V.copy()
+        return out
+
+    # Don't use me. Use dot instead
+    def vdot(self, V):
+        return sparse.VectorDotProduct(self.ones, V)
+
+    # Don't use me. Use dot instead
+    def mdot(self, V):
+        return sparse.MatrixDotProduct(self.ones, V)
+
+    # Don't use me. Use dot instead
+    def vmProd(self, V):
+        m = sparse.VectorMatrixProduct(list(self.ones), V)
+        # out = np.zeros((self.shape[0], V.shape[1]))
+        # for c in range(V.shape[1]):
+        #     out[0, c] = float(sum(V[self.ones, c]))
+
+        return m
+
+    # Should operate exactly as numpy's dot method.
+    def dot(self, V):
+        if len(V.shape) == 2:
+            out = []
+            if self.shape[1] == 1 and V.shape[0] == 1: # Outer product
+                out = self.outer(V)
+            elif self.shape[0] == 1 and V.shape[0] == 1: # must be a vector dot product
+                out = self.vdot(V)
+            elif self.shape[0] == 1 and V.shape[1] == 1: # must be a matrix dot product
+                out = self.mdot(V)
+            elif self.shape[0] == 1 and V.shape[1] > 1: # vector-matrix product
+                out = self.vmProd(V)
+            else:
+                raise IndexError
+            return out
+        else:
+            return np.array(float(sum(V[self.ones])))
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def __add__(self, other):
+        if len(other.shape) == 2:
+            raise NotImplementedError
+        m = other.copy()
+        m[self.ones] = 1 + m[self.ones]
+        return m
+
+    def __sub__(self, other):
+        if len(other.shape) == 2:
+            return self.array() - other
+        else:
+            return self.array() - other
+
+    def __rsub__(self, other):
+        if len(other.shape) == 2:
+            m = other.copy()
+            m[0, self.ones] = m[0, self.ones] - 1
+            return m
+        else:
+            m = other.copy()
+            m[self.ones] = m[self.ones] - 1
+            return m
+
+    def __mul__(self, other):
+        m = np.zeros(self.shape)
+        m[self.ones] = other
+        return m
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+class SparseTC(object):
+    def __init__(self, args):
+        self.tilings = args['tilings']
+        self.tiles = args['tiles']
+        self.dims = args['dims']
+        self.actions = args['actions']
+
+        self.tc = TileCoding(self.dims, self.tilings, self.tiles, self.actions)
+
+    def features(self):
+        return int(self.tiles**self.dims * self.tilings * self.actions)
+
+    def representation(self, s, a):
+        idx = self.tc.get_index(s, a)
+        vec = SparseOneVector(list(idx), self.features())
+        return vec
+


### PR DESCRIPTION
This adds the continuous gridworld and generalizes the tile-coded linear q agent. I'm using a homebrewed sparse vector implementation to dramatically speed up the algorithm (function approximation is much slower than tabular). The c code has been used in research projects for a couple of years now, and is pretty thoroughly tested (plus apparently I wrote some really sketchy unit tests back then :laughing: )

You'll have to compile and install the c code so that python can dynamically load it. There's a bash script, `build.sh`, which should do this for you. So just run:
```bash
sh build.sh
```
once, and you should forever be able to use the sparse module (it should never change, so no need to worry about rebuilding).

I'll start adding my experiment framework now as well so we can really start running some experiments.