### PR TITLE
add basic parameter sweep experiment framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 *~
 *.pyc
 lib/
+results/
 sparse/build
 
 figs/

--- a/ExperimentDescription.py
+++ b/ExperimentDescription.py
@@ -1,0 +1,128 @@
+import json
+import re
+
+class ExperimentDescription:
+    def __init__(self, file_path, idx, runs = 20):
+        with open(file_path, 'r') as f:
+            exp_data = json.load(f)
+
+        self.runs = runs
+        self.agent = exp_data['agent']
+        self.environment = exp_data['environment']
+        self.env_params = exp_data['envParameters']
+        self.name = exp_data['name']
+
+        sweep_data = exp_data['metaParameters']
+        self.num_permutations = getNumberOfPermutations(sweep_data)
+        self.meta_parameters = getParameterPermutation(sweep_data, idx)
+
+        self.run = idx // self.num_permutations
+
+    def getParamString(self):
+        params = []
+        for key in self.meta_parameters:
+            value = self.meta_parameters[key]
+            params.append(f'{key}-{value}')
+
+        return '_'.join(params)
+
+def getParameterPermutation(sweeps, index):
+    pairs = flattenToArray(sweeps)
+    perm = {}
+    accum = 1
+
+    for pair in pairs:
+        key, values = pair
+        num = len(values)
+
+        # if we have an empty array for a parameter, add that parameter back as an empty array
+        if num == 0:
+            perm[key] = []
+            continue
+
+        perm[key] = values[(index // accum) % num]
+        accum *= num
+
+    return reconstructParameters(perm)
+
+def reconstructParameters(perm):
+    res = {}
+    for key in perm:
+        set_at_path(res, key, perm[key])
+
+    return res
+
+
+def getNumberOfPermutations(thing):
+    pairs = flattenToArray(thing)
+    accum = 1
+    for pair in pairs:
+        path, values = pair
+        num = len(values) if len(values) > 0 else 1
+        accum *= num
+
+    return accum
+
+def flattenToArray(thing):
+    accum = []
+
+    def inner(thing, path):
+        if isinstance(thing, list):
+            # check if list contains objects
+            # if it does, keep recurring
+            if isinstance(thing[0], dict):
+                i = 0
+                for sub in thing:
+                    inner(sub, f'{path}.[{i}]')
+                    i += 1
+                return
+
+            accum.append((path, thing))
+            return
+
+        if isinstance(thing, dict):
+            for key in thing:
+                new_path = key if path == '' else f'{path}.{key}'
+                inner(thing[key], new_path)
+            return
+
+        accum.append(( path, [thing] ))
+        return
+
+    inner(thing, '')
+    return accum
+
+def set_at_path(d, path, val):
+    def inner(d, path, val, last):
+        if len(path) == 0: return d
+        split = path.split('.', maxsplit = 1)
+
+        part, rest = split if len(split) > 1 else [split[0], '']
+        nxt = rest.split('.')[0]
+
+        # lists
+        if part.startswith('['):
+            num = int(re.sub(r'[\[,\]]', '', part))
+
+            if len(d[last]) > num:
+                piece = inner(d[last][num], rest, val, '') if len(rest) > 0 else val
+                d[last][num] = piece
+            else:
+                piece = inner({}, rest, val, '') if len(rest) > 0 else val
+                d[last].append(piece)
+            return d
+        # objects
+        elif len(rest) > 0:
+            if nxt.startswith('['):
+                piece = d.setdefault(part, [])
+                return inner(d, rest, val, part)
+            else:
+                piece = d.setdefault(part, {})
+                return inner(piece, rest, val, part)
+        # everything else
+        else:
+            d.setdefault(part, val)
+            return d
+
+    inner(d, path, val, '')
+    return d

--- a/agents/Agent.py
+++ b/agents/Agent.py
@@ -1,7 +1,8 @@
 class Agent:
-    def __init_(self, state_shape, num_acts):
+    def __init_(self, state_shape, num_acts, params):
         self.state_shape = state_shape
         self.num_acts = num_acts
+        self.params = params
 
     # should take a state and return an action
     # also responsible for setting up any memory the agent may need
@@ -19,3 +20,11 @@ class Agent:
     # takes the current state and returns the action
     def getAction(self, s):
         raise NotImplementedError
+
+    def getParamString(self):
+        params = []
+        for key in self.params:
+            value = self.params[key]
+            params.append(f'{key}-{value}')
+
+        return '_'.join(params)

--- a/agents/LinearQ.py
+++ b/agents/LinearQ.py
@@ -6,12 +6,12 @@ from utils.TileCoding import TileCoding
 from utils.sparse import SparseTC
 
 class LinearQ(Agent):
-    def __init__(self, state_shape, num_acts):
-        self.tiles = 2
-        self.tilings = 8
-        self.epsilon = 0.1
-        self.gamma = 0.9
-        self.alpha = 0.1 / float(self.tilings)
+    def __init__(self, state_shape, num_acts, params):
+        self.tiles = params['tiles']
+        self.tilings = params['tilings']
+        self.epsilon = params['epsilon']
+        self.gamma = params['gamma']
+        self.alpha = params['alpha'] / float(self.tilings)
 
         self.state_shape = state_shape
         self.num_states = np.prod(state_shape)

--- a/agents/TabularQ.py
+++ b/agents/TabularQ.py
@@ -3,10 +3,10 @@ from agents.Agent import Agent
 from utils.math import argMax
 
 class TabularQ(Agent):
-    def __init__(self, state_shape, num_acts):
-        self.alpha = 0.5
-        self.gamma = 0.9
-        self.epsilon = 0.1
+    def __init__(self, state_shape, num_acts, params):
+        self.alpha = params['alpha']
+        self.gamma = params['gamma']
+        self.epsilon = params['epsilon']
 
         self.state_shape = state_shape
         self.num_states = np.prod(state_shape)

--- a/agents/TabularRTabularQ.py
+++ b/agents/TabularRTabularQ.py
@@ -3,10 +3,9 @@ from agents.TabularQ import TabularQ
 from bayesianapproximator import TabularBayesianApproximation
 
 class TabularRTabularQ(TabularQ):
-    def __init__(self, state_shape, num_acts):
-        super().__init__(state_shape, num_acts)
+    def __init__(self, state_shape, num_acts, params):
+        super().__init__(state_shape, num_acts, params)
         self.rewardApprox = TabularBayesianApproximation(state_shape, num_acts)
-        self.epsilon = 0.05
 
     def update(self, s, sp, r, a, done):
         self.rewardApprox.update_stats(s, a, r)

--- a/agents/UCB.py
+++ b/agents/UCB.py
@@ -3,10 +3,9 @@ from agents.TabularQ import TabularQ
 from bayesianapproximator import TabularBayesianApproximation
 
 class UCB(TabularQ):
-    def __init__(self, state_shape, num_acts):
-        super().__init__(state_shape, num_acts)
-        self.epsilon = 0.05
-        self.c = 0.01
+    def __init__(self, state_shape, num_acts, params):
+        super().__init__(state_shape, num_acts, params)
+        self.c = params['c']
 
         self.N = np.zeros((np.prod(state_shape), num_acts))
         self.steps = 0

--- a/bayesianapproximator.py
+++ b/bayesianapproximator.py
@@ -49,7 +49,6 @@ class TabularBayesianApproximation(BayesianApproximator):
     r = t.rvs(df=df, loc=mu, scale=scale, size=1000)
     bonus = max(np.append(r, 0.0)) - np.average(r)
     mean, var, skew, kurt = t.stats(df=df, loc=mu, scale=scale, moments='mvsk')
-    print(var)
     self.action_var[a][s_idx] = var
     # maybe we could check that the variance is -> 0 for each (s, a)
     if use_stddev:

--- a/environments/ContinuousGridworld.py
+++ b/environments/ContinuousGridworld.py
@@ -6,11 +6,11 @@ class CtsGridWorld(Environment):
     _y = 0
 
     steps = 0
-    stepSize = 0.05
     noise = 0.01
 
-    def __init__(self, maxSteps):
-        self.maxSteps = maxSteps
+    def __init__(self, params):
+        self.maxSteps = params['steps']
+        self.stepSize = params['stepsize']
 
     def getReward(self):
         if self._x + self.stepSize >= 1 and self._y + self.stepSize >= 1:

--- a/environments/gridworld.py
+++ b/environments/gridworld.py
@@ -7,9 +7,9 @@ class GridWorld(Environment):
 
     steps = 0
 
-    def __init__(self, shape, maxSteps):
-        self.shape = shape
-        self.maxSteps = maxSteps
+    def __init__(self, params):
+        self.shape = params['shape']
+        self.maxSteps = params['steps']
 
     def getReward(self):
         if self._x == self.shape[0] - 1 and self._y == self.shape[1] - 1:

--- a/experiments/tabular/sweeps/egreedy.json
+++ b/experiments/tabular/sweeps/egreedy.json
@@ -1,0 +1,15 @@
+{
+    "name": "tabular",
+    "agent": "tabular-q",
+    "environment": "gridworld",
+    "metaParameters": {
+        "alpha": [0.1, 0.2, 0.4, 0.8, 1.6],
+        "epsilon": [0.05, 0.1, 0.2],
+        "gamma": 0.9
+    },
+    "envParameters": {
+        "shape": [30, 30],
+        "steps": 700,
+        "episodes": 1000
+    }
+}

--- a/experiments/tabular/sweeps/tabular-r.json
+++ b/experiments/tabular/sweeps/tabular-r.json
@@ -1,0 +1,15 @@
+{
+    "name": "tabular",
+    "agent": "tabular-r tabular-q",
+    "environment": "gridworld",
+    "metaParameters": {
+        "alpha": [0.1, 0.2, 0.4, 0.8, 1.6],
+        "epsilon": [0.05, 0.1, 0.2],
+        "gamma": 0.9
+    },
+    "envParameters": {
+        "shape": [30, 30],
+        "steps": 700,
+        "episodes": 1000
+    }
+}

--- a/experiments/tabular/sweeps/ucb.json
+++ b/experiments/tabular/sweeps/ucb.json
@@ -1,0 +1,16 @@
+{
+    "name": "tabular",
+    "agent": "ucb",
+    "environment": "gridworld",
+    "metaParameters": {
+        "alpha": [0.1, 0.2, 0.4, 0.8, 1.6],
+        "epsilon": [0.05, 0.1, 0.2],
+        "c": [0.001, 0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256],
+        "gamma": 0.9
+    },
+    "envParameters": {
+        "shape": [30, 30],
+        "steps": 700,
+        "episodes": 1000
+    }
+}

--- a/utils/registry.py
+++ b/utils/registry.py
@@ -1,0 +1,31 @@
+# agents
+from agents.TabularQ import TabularQ
+from agents.LinearQ import LinearQ
+from agents.TabularRTabularQ import TabularRTabularQ
+from agents.BnnRTabularQ import BnnRTabularQ
+from agents.RiverswimOptimal import Optimal
+from agents.UCB import UCB
+
+# environments
+from environments.gridworld import GridWorld
+from environments.ContinuousGridworld import CtsGridWorld
+
+def getAgent(exp):
+    if exp.agent == 'linear-q':
+        return LinearQ
+    if exp.agent == 'tabular-q':
+        return TabularQ
+    if exp.agent == 'ucb':
+        return UCB
+    if exp.agent == 'tabular-r tabular-q':
+        return TabularRTabularQ
+
+    raise NotImplementedError
+
+def getEnvironment(exp):
+    if exp.environment == 'cts-gridworld':
+        return CtsGridWorld
+    if exp.environment == 'gridworld':
+        return GridWorld
+
+    raise NotImplementedError


### PR DESCRIPTION
This adds the first pieces of the experiment framework. This should make it much easier to run parameter sweep experiments. For now, we can measure the performance of the parameter choice by taking the mean over our metric (number of steps/episode).

I added some sample experiment files in the `experiments` folder. I _always_ keep an `experiments` folder in my research repos. It is the source of truth for the current experiments that I am working with. When I publish a paper I can look through that folder to know what experiments were run, and with what settings.

To run the code now requires some command line parameters. You can run the code with:
```bash
python q_learning.py -e experiments/tabular/sweeps/ucb.json -r 20 -i 0
```
This will do 20 runs with the first permutation of parameters.

I'll add some utility files for running all of the parameter permutations parallelized across multiple cpu cores later.