### PR TITLE
Changes to the `TabularBayesianApproximation` class, so that they are…

### DIFF
--- a/agents/TabularRTabularQ.py
+++ b/agents/TabularRTabularQ.py
@@ -10,6 +10,5 @@ class TabularRTabularQ(TabularQ):
     def update(self, s, sp, r, a, done):
         x = self.getIndex(s) + (a * self.num_states)
         self.rewardApprox.update_stats(x, r)
-        samples = self.rewardApprox.sample(x, 100)
-        bonus = samples[0] # wouldn't this raise a type error?
+        bonus = self.rewardApprox.sample(x, 100)
         super().update(s, sp, r + bonus, a, done)

--- a/utils/bayesianapproximator.py
+++ b/utils/bayesianapproximator.py
@@ -30,7 +30,8 @@ class TDistBayesianApproximation(BayesianApproximator):
         num_dims = np.square(params["tiles"]) * params["tilings"] * num_acts
         normal_prior = MultivariateNormal.from_shared_mean_and_log_precision(
             params["normal_prior_mean"],
-            params["normal_prior_log_precision"],   # small precision = large variance
+            params[
+                "normal_prior_log_precision"],  # small precision = large variance
             num_dims=num_dims)
         self.mnig_prior = MultivariateNormalInverseGamma(
             normal_prior, ig_prior)
@@ -49,30 +50,46 @@ class TDistBayesianApproximation(BayesianApproximator):
 
 
 class TabularBayesianApproximation(BayesianApproximator):
-  def __init__(self, state_dimensions, num_acts):
+    def __init__(self, state_dimensions, num_acts):
         super().__init__(state_dimensions, num_acts)
         num_states = np.prod(state_dimensions)
         self.state_shape = state_dimensions
         self.B = np.zeros((num_states * num_acts, 4))
-        # prior sample mean
-        # prior "observations to make that mean"
-        # prior "observations to make our variance" # try to make it hard to reduce this
-        # prior sum of square errors (proportional to initial sample variance)
-        self.B[:] = [1, 1, 2, 1]
-        self.action_var = [np.zeros(num_states)] * num_acts
+        self.mu_0 = 1.0  # prior sample mean
+        self.nu_0 = 1.0  # prior "observations that make the prior mean"
+        self.alpha_0 = 0.1  # prior IG shape
+        self.beta_0 = 1.0  # prior IG scale
 
-  def update_stats(self, x, val=0.0): # the default of the new value is 0 for exploration bonuses
-    mu, nu, alpha, beta = self.B[x, :]
-    self.B[x, 0] = (nu * mu + val) / (nu + 1)
-    self.B[x, 1] = nu + 1
-    self.B[x, 2] = alpha + 1.0/2.0
-    self.B[x, 3] = (nu / (nu + 1.0)) * math.pow((val - mu), 2.0) / 2.0
+        self.B[:] = [self.mu_0, self.nu_0, self.alpha_0, self.beta_0]
 
-  def sample(self, x, n, use_stddev=False):
-    mu, nu, alpha, beta = self.B[x, :]
-    scale = beta * (nu + 1)/(alpha * nu)
-    df = 2 * alpha
-    r = t.rvs(df=df, loc=mu, scale=scale, size=n)
-    bonus = max(np.append(r, 0.0)) - np.average(r)
-    # mean, var, skew, kurt = t.stats(df=df, loc=mu, scale=scale, moments='mvsk')
-    return [bonus]
+        # To update beta, we need to keep track of the following 3 values for each (s,a)
+        self.empirical_mean = np.zeros((num_states * num_acts))
+        self.n = np.zeros(
+            (num_states * num_acts))  # local count for each (s, a) pair
+        self.local_sum_sq = np.zeros((num_states * num_acts))
+
+    def update_stats(self, x, val=0.0):
+        self.n[x] += 1  # local count
+        self.empirical_mean[x] += (val - self.empirical_mean[x]) / self.n[x]
+        self.local_sum_sq[x] += np.square(val)
+
+        self.B[x, 0] = (self.nu_0 * self.mu_0 + self.n[x] *
+                        self.empirical_mean[x]) / (self.nu_0 + self.n[x])
+        self.B[x, 1] = self.nu_0 + self.n[x]
+        self.B[x, 2] = self.alpha_0 + self.n[x] / 2
+        self.B[x, 3] = (self.beta_0 + 0.5
+            * (self.local_sum_sq[x] - self.n[x] * np.square(self.empirical_mean[x]))
+            + (self.n[x] * self.nu_0) / (self.nu_0 + self.n[x])
+            * 0.5 * np.square(self.empirical_mean[x] - self.mu_0))
+
+    def sample(self, x, n, use_stddev=False):
+        mu, nu, alpha, beta = self.B[x, :]
+        scale = max(0, beta * (nu + 1) / (alpha * nu)) # Make sure that the scale is >= 0
+        df = 2 * alpha
+        try:
+            r = t.rvs(df=df, loc=mu, scale=scale, size=n)
+        except:
+            print(scale)
+            exit()
+        bonus = np.maximum(r, 0.0) - np.average(r)
+        return bonus.max()


### PR DESCRIPTION
… consistent with the update rule in the `Bayesian Q-learning` paper.

Suggestion: move the prior `mu_0, nu_0, alpha_0, beta_0` parameters to 
the `tabular-r.json` file for parameter sweeps.